### PR TITLE
Update package version and add GridifyExtensions

### DIFF
--- a/src/SharedKernel/SharedKernel.csproj
+++ b/src/SharedKernel/SharedKernel.csproj
@@ -8,18 +8,18 @@
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
         <Authors>Pandatech</Authors>
         <Copyright>MIT</Copyright>
-        <Version>1.2.11</Version>
+        <Version>1.2.12</Version>
         <PackageId>Pandatech.SharedKernel</PackageId>
         <Title>Pandatech Shared Kernel Library</Title>
         <PackageTags>Pandatech, shared kernel, library, OpenAPI, Swagger, utilities, scalar</PackageTags>
         <Description>Pandatech.SharedKernel provides centralized configurations, utilities, and extensions for ASP.NET Core projects. For more information refere to readme.md document.</Description>
         <RepositoryUrl>https://github.com/PandaTechAM/be-lib-sharedkernel</RepositoryUrl>
-        <PackageReleaseNotes>Package update</PackageReleaseNotes>
+        <PackageReleaseNotes>Updated Gridify Extensions</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\..\pandatech.png" Pack="true" PackagePath="\"/>
-        <None Include="..\..\Readme.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\pandatech.png" Pack="true" PackagePath="\" />
+        <None Include="..\..\Readme.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
     <ItemGroup>
@@ -41,7 +41,7 @@
         <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.2" />
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
-        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0-rc.1"/>
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0-rc.1" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
@@ -51,6 +51,7 @@
         <PackageReference Include="Pandatech.DistributedCache" Version="4.0.7" />
         <PackageReference Include="PandaTech.FileExporter" Version="4.0.2" />
         <PackageReference Include="Pandatech.FluentMinimalApiMapper" Version="2.0.2" />
+        <PackageReference Include="Pandatech.GridifyExtensions" Version="2.0.3" />
         <PackageReference Include="Pandatech.PandaVaultClient" Version="4.0.4" />
         <PackageReference Include="Pandatech.RegexBox" Version="3.0.1" />
         <PackageReference Include="Pandatech.ResponseCrafter" Version="5.1.8" />


### PR DESCRIPTION
- Bump package version from 1.2.11 to 1.2.12.
- Update release notes to "Updated Gridify Extensions".
- Adjust formatting of `None` elements for consistency.
- Add new package reference for `Pandatech.GridifyExtensions` (v2.0.3).
- Correct formatting of `OpenTelemetry.Exporter.Prometheus.AspNetCore` reference.